### PR TITLE
Issue #841 - Fixed color palette, so curretly selected is used

### DIFF
--- a/ding_base.module
+++ b/ding_base.module
@@ -475,7 +475,7 @@ function ding_base_rewrite_color_stylesheet() {
   }
 
   $info = color_get_info($theme);
-  $palette = color_get_palette($theme, TRUE);
+  $palette = color_get_palette($theme);
 
   // Prepare target locations for generated files.
   $id = $theme . '-' . substr(hash('sha256', serialize($palette) . microtime()), 0, 8);


### PR DESCRIPTION
Updated the cgen function to not use the themes default palette, but the one currently used by the theme.

See http://platform.dandigbib.org/issues/841